### PR TITLE
major: add id and hash field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,5 @@ jobs:
       - uses: fastify/github-action-merge-dependabot@v2.7.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          target: minor
+

--- a/README.md
+++ b/README.md
@@ -32,7 +32,17 @@ npm install fastify-overview
 
 ## Usage
 
-This plugin is super simple, just add it to your fastify instance and you will get a `overview()` method that will return a tree structure of your application:
+This plugin is super simple, just add it to your fastify instance and you will get a `overview()` method that will return a tree structure of your application.
+
+There are 3 things to know:
+
+1. It starts tracking your application after the `await register()` of the plugin:
+    - what happens before, it is **not** tracked. So **this plugin must be the first one** to be registered.
+    - it the `register` is not awaited, the structure will **not** be tracked.
+2. The application structure can be accessed **after** the Fastify instance is `ready`. If you try to get it before the `ready` status, you will get an error.
+3. The structure tracks hooks' name and decorators' name. If you use arrow functions the structure will be useless/unreadable.
+
+Here the code:
 
 ```js
 const fastify = require('fastify')
@@ -66,14 +76,6 @@ async function run() {
 run()
 ```
 
-To use this plugin there are 3 things to know:
-
-1. It starts tracking your application after the `await register()` of the plugin:
-    - what happens before, it is **not** tracked.
-    - it the `register` is not awaited, the structure will be **not** tracked.
-2. The application structure can be accessed **after** the Fastify instance is `ready`. If you try to get it before the `ready` status, you will get an error.
-3. The structure tracks hooks' name and decorators' name. If you use arrow functions the structure will be useless/unreadable.
-
 ### Structure
 
 The JSON structure returned by the `overview` method is like the following:
@@ -91,7 +93,12 @@ The JSON structure returned by the `overview` method is like the following:
     "decorateReply": [] // app.decorateReply('foo-bar', 42)
   },
   "hooks": { // all the instance hooks
-    "onRequest": [ "hook1" ], // app.addHook('onRequest', function hook1 (){})
+    "onRequest": [
+      {
+        "name": "hook1" // the function name: app.addHook('onRequest', function hook1 (){})
+        "hash": "92b002434cd5d8481e7e5562b51df679e2f8d586" // the function hash. Useful to identify optimizations
+      }
+    ],
     "preParsing": [],
     "preValidation": [],
     "preHandler": [],
@@ -114,10 +121,16 @@ The JSON structure returned by the `overview` method is like the following:
         "onRequest": [],
         "preParsing": [],
         "preValidation": [
-          "Anonymous function"
+          {
+            "name": "Anonymous function",
+            "hash": "ade00501a7c8607ba74bf5e13d751da2139c4e60"
+          }
         ],
         "preHandler": [
-          "hook1"
+          {
+            "name": "hook1",
+            "hash": "9398f5df01879094095221d86a544179e62cee12"
+          }
         ],
         "preSerialization": [],
         "onError": [],

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The JSON structure returned by the `overview` method is like the following:
     // it contains the same structure we are describing
   ], 
   "decorators": { // all the instance decorators | app.decorate('foo-bar', 42)
-    "decorate": [ "foo-bar" ], // the decorators' name
+    "decorate": [ { "name": "foo-bar" } ], // the decorators' name
     "decorateRequest": [], // app.decorateRequest('foo-bar', 42)
     "decorateReply": [] // app.decorateReply('foo-bar', 42)
   },

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The JSON structure returned by the `overview` method is like the following:
 
 ```js
 {
+  "id": 0.331, // an internal id number. You can use it to identify the node
   "name": "pluginName", // the name of the plugin | app.register(function pluginName (){})
   "children": [ // the children of the fastify instance | instance.register(function subPlugin (){})
     // it contains the same structure we are describing

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function wrapFastify (instance) {
 function wrapDecorator (instance, type) {
   const originalDecorate = instance[type]
   instance[type] = function wrapDecorate (name, value) {
-    this[kStructure].decorators[type].push(name)
+    this[kStructure].decorators[type].push({ name })
     return originalDecorate.call(this, name, value)
   }
 }

--- a/index.js
+++ b/index.js
@@ -5,9 +5,9 @@ const kTrackerMe = Symbol('fastify-overview.track-me')
 const kStructure = Symbol('fastify-overview.structure')
 
 const {
-  getFunctionName,
   transformRoute,
-  getEmptyTree
+  getPluginNode,
+  getHookNode
 } = require('./lib/utils')
 
 function fastifyOverview (fastify, options, next) {
@@ -46,7 +46,7 @@ function fastifyOverview (fastify, options, next) {
     const trackingToken = Math.random()
     instance[kTrackerMe] = trackingToken
 
-    const trackStructure = getEmptyTree(trackingToken, instance.pluginName)
+    const trackStructure = getPluginNode(trackingToken, instance.pluginName)
     if (parentId) {
       contextMap.get(parentId).children.push(trackStructure)
     }
@@ -74,7 +74,7 @@ function wrapFastify (instance) {
 
   const originalHook = instance.addHook
   instance.addHook = function wrapAddHook (name, hook) {
-    this[kStructure].hooks[name].push(getFunctionName(hook.toString()))
+    this[kStructure].hooks[name].push(getHookNode(hook))
     return originalHook.call(this, name, hook)
   }
 }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const {
   getEmptyTree
 } = require('./lib/utils')
 
-function fastifyOverview (fastify, opts, next) {
+function fastifyOverview (fastify, options, next) {
   const contextMap = new Map()
   let structure
 
@@ -46,7 +46,7 @@ function fastifyOverview (fastify, opts, next) {
     const trackingToken = Math.random()
     instance[kTrackerMe] = trackingToken
 
-    const trackStructure = getEmptyTree(instance.pluginName)
+    const trackStructure = getEmptyTree(trackingToken, instance.pluginName)
     if (parentId) {
       contextMap.get(parentId).children.push(trackStructure)
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,8 +37,9 @@ function transformRoute (routeOpts) {
   }
 }
 
-function getEmptyTree (name) {
+function getEmptyTree (id, name) {
   return {
+    id,
     name,
     children: [],
     routes: [],

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,11 @@
 'use strict'
 
+const hash = require('object-hash')
+
 module.exports = {
-  getFunctionName,
   transformRoute,
-  getEmptyTree
+  getPluginNode,
+  getHookNode
 }
 
 function getFunctionName (func) {
@@ -22,9 +24,9 @@ function transformRoute (routeOpts) {
   for (const hook of Object.keys(hooks)) {
     if (routeOpts[hook]) {
       if (Array.isArray(routeOpts[hook])) {
-        hooks[hook] = routeOpts[hook].map(getFunctionName)
+        hooks[hook] = routeOpts[hook].map(getHookNode)
       } else {
-        hooks[hook].push(getFunctionName(routeOpts[hook]))
+        hooks[hook].push(getHookNode(routeOpts[hook]))
       }
     }
   }
@@ -37,7 +39,7 @@ function transformRoute (routeOpts) {
   }
 }
 
-function getEmptyTree (id, name) {
+function getPluginNode (id, name) {
   return {
     id,
     name,
@@ -52,6 +54,13 @@ function getEmptyTree (id, name) {
       ...getEmptyHookRoute(),
       ...getEmptyHookApplication()
     }
+  }
+}
+
+function getHookNode (hookFunction) {
+  return {
+    name: getFunctionName(hookFunction),
+    hash: hash(hookFunction)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "tap": "^15.0.9"
   },
   "dependencies": {
-    "fastify-plugin": "^3.0.0"
+    "fastify-plugin": "^3.0.0",
+    "object-hash": "^2.2.0"
   }
 }

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -36,23 +36,23 @@ test('decorator', async t => {
   t.equal(root.children.length, 2)
   t.equal(root.children[0].name, 'register1')
   t.equal(root.children[1].name, 'sibling')
-  t.same(root.decorators.decorate, ['root-func'])
-  t.same(root.decorators.decorateRequest, ['root-req', 'root-req-two'])
-  t.same(root.decorators.decorateReply, ['root-reply'])
+  t.same(root.decorators.decorate, [{ name: 'root-func' }])
+  t.same(root.decorators.decorateRequest, [{ name: 'root-req' }, { name: 'root-req-two' }])
+  t.same(root.decorators.decorateReply, [{ name: 'root-reply' }])
 
   const reg1 = root.children[0]
   t.same(reg1.decorators.decorate, [])
-  t.same(reg1.decorators.decorateRequest, ['child-1'])
+  t.same(reg1.decorators.decorateRequest, [{ name: 'child-1' }])
   t.same(reg1.decorators.decorateReply, [])
   t.equal(reg1.children.length, 2)
 
   const reg2 = reg1.children[0]
   t.same(reg2.decorators.decorate, [])
   t.same(reg2.decorators.decorateRequest, [])
-  t.same(reg2.decorators.decorateReply, ['sub'])
+  t.same(reg2.decorators.decorateReply, [{ name: 'sub' }])
 
   const reg3 = reg1.children[1]
-  t.same(reg3.decorators.decorate, ['sub-instance'])
+  t.same(reg3.decorators.decorate, [{ name: 'sub-instance' }])
   t.same(reg3.decorators.decorateRequest, [])
-  t.same(reg3.decorators.decorateReply, ['sub'])
+  t.same(reg3.decorators.decorateReply, [{ name: 'sub' }])
 })

--- a/test/fixture/index.00.json
+++ b/test/fixture/index.00.json
@@ -1,0 +1,60 @@
+{
+  "onRequest": [
+    {
+      "name": "hook1",
+      "hash": "31d31d981f412085927efb5e9f36be8ba905516a"
+    }
+  ],
+  "preParsing": [
+    {
+      "name": "hook2",
+      "hash": "07f8fc52f2a92adc80881b4c11ee61ab56ea42d1"
+    }
+  ],
+  "preValidation": [
+    {
+      "name": "hook3",
+      "hash": "92b002434cd5d8481e7e5562b51df679e2f8d586"
+    }
+  ],
+  "preHandler": [
+    {
+      "name": "hook4",
+      "hash": "ade00501a7c8607ba74bf5e13d751da2139c4e60"
+    }
+  ],
+  "preSerialization": [
+    {
+      "name": "hook5",
+      "hash": "b9e63b1b61cda28d6f1c8a341fddba8196d6be0d"
+    }
+  ],
+  "onError": [
+    {
+      "name": "hookSix",
+      "hash": "9398f5df01879094095221d86a544179e62cee12"
+    }
+  ],
+  "onSend": [
+    {
+      "name": "hook_7",
+      "hash": "d3cd1cc0cf04b9fda85a84decae619851c739f7e"
+    }
+  ],
+  "onResponse": [
+    {
+      "name": "hook8",
+      "hash": "62e68924a1b57f5950068c398fa3d231f1a0280f"
+    }
+  ],
+  "onTimeout": [
+    {
+      "name": "Anonymous function",
+      "hash": "eddae38f899bec68b598177766919cfbb91bb520"
+    }
+  ],
+  "onReady": [],
+  "onClose": [],
+  "onRoute": [],
+  "onRegister": []
+}

--- a/test/fixture/routes.02.json
+++ b/test/fixture/routes.02.json
@@ -8,8 +8,14 @@
       "preParsing": [],
       "preValidation": [],
       "preHandler": [
-        "hook1",
-        "hook2"
+        {
+          "name": "hook1",
+          "hash": "31d31d981f412085927efb5e9f36be8ba905516a"
+        },
+        {
+          "name": "hook2",
+          "hash": "07f8fc52f2a92adc80881b4c11ee61ab56ea42d1"
+        }
       ],
       "preSerialization": [],
       "onError": [],
@@ -26,10 +32,16 @@
       "onRequest": [],
       "preParsing": [],
       "preValidation": [
-        "Anonymous function"
+        {
+          "name": "Anonymous function",
+          "hash": "be7cc9b39f55888e403234868fc52a632dbae242"
+        }
       ],
       "preHandler": [
-        "hook1"
+        {
+          "name": "hook1",
+          "hash": "31d31d981f412085927efb5e9f36be8ba905516a"
+        }
       ],
       "preSerialization": [],
       "onError": [],

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -39,7 +39,11 @@ test('basic test', async t => {
   const structure = app.overview()
   t.type(structure.id, 'number')
   t.equal(structure.children.length, 3)
-  t.same(structure.decorators.decorate, ['test', 'testObject', 'testArray'])
+  t.same(structure.decorators.decorate, [
+    { name: 'test' },
+    { name: 'testObject' },
+    { name: 'testArray' }
+  ])
   t.same(structure.hooks, require('./fixture/index.00.json'))
 })
 
@@ -67,7 +71,7 @@ test('register', async t => {
 
   t.equal(root.children.length, 1)
   t.equal(root.children[0].name, 'register1')
-  t.same(root.decorators.decorate, ['foo-bar'])
+  t.same(root.decorators.decorate, [{ name: 'foo-bar' }])
   t.equal(root.hooks.onRequest.length, 0)
   t.equal(root.hooks.preParsing.length, 0)
   t.equal(root.hooks.preValidation.length, 0)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -37,6 +37,7 @@ test('basic test', async t => {
 
   await app.ready()
   const structure = app.overview()
+  t.type(structure.id, 'number')
   t.equal(structure.children.length, 3)
   t.same(structure.decorators.decorate, ['test', 'testObject', 'testArray'])
   t.same(structure.hooks.onRequest, ['hook1'])
@@ -86,6 +87,7 @@ test('register', async t => {
   t.equal(root.hooks.onTimeout.length, 0)
 
   const reg1 = root.children[0]
+  t.type(reg1.id, 'number')
   t.equal(reg1.children.length, 2)
   t.equal(reg1.children[0].name, 'register2')
   t.equal(reg1.children[1].name, 'register3')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -40,15 +40,7 @@ test('basic test', async t => {
   t.type(structure.id, 'number')
   t.equal(structure.children.length, 3)
   t.same(structure.decorators.decorate, ['test', 'testObject', 'testArray'])
-  t.same(structure.hooks.onRequest, ['hook1'])
-  t.same(structure.hooks.preParsing, ['hook2'])
-  t.same(structure.hooks.preValidation, ['hook3'])
-  t.same(structure.hooks.preHandler, ['hook4'])
-  t.same(structure.hooks.preSerialization, ['hook5'])
-  t.same(structure.hooks.onError, ['hookSix'])
-  t.same(structure.hooks.onSend, ['hook_7'])
-  t.same(structure.hooks.onResponse, ['hook8'])
-  t.same(structure.hooks.onTimeout, ['Anonymous function'])
+  t.same(structure.hooks, require('./fixture/index.00.json'))
 })
 
 test('register', async t => {


### PR DESCRIPTION
Add:

- id property on plugin nodes
- change the hook structure from string array to json array:

Doing so we are open to adding a new `source` node on plugins and hooks.

I'm wondering if we should do the same for decorators. Opinions?