### PR TITLE
Update `RouteItem` and add test cases

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ interface OverviewStructureHooks {
 }
 
 interface RouteItem {
-  method: HTTPMethods,
+  method: HTTPMethods | HTTPMethods[],
   url: string,
   prefix: string,
   hooks: OverviewStructureHooks,

--- a/test/fixture/routes.00.json
+++ b/test/fixture/routes.00.json
@@ -134,5 +134,26 @@
       "onTimeout": [],
       "onRequestAbort": []
     }
+  },
+  {
+    "method":[
+      "GET",
+      "POST",
+      "PROPPATCH"
+    ],
+    "url":"/array",
+    "prefix":"",
+    "hooks":{
+      "onRequest":[ ],
+      "preParsing":[ ],
+      "preValidation":[ ],
+      "preHandler":[ ],
+      "preSerialization":[ ],
+      "onError":[ ],
+      "onSend":[ ],
+      "onResponse":[ ],
+      "onTimeout":[ ],
+      "onRequestAbort":[ ]
+    }
   }
 ]

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -27,6 +27,11 @@ test('routes', async t => {
     url: '/route-post-chain',
     handler: noop
   })
+  app.route({
+    method: ['GET', 'POST', 'PROPPATCH'],
+    url: '/array',
+    handler () {}
+  })
 
   app.register(function register1 (instance, opts, next) {
     instance.get('/get', noop)
@@ -66,7 +71,7 @@ test('routes', async t => {
   t.equal(root.children.length, 2)
   t.equal(root.children[0].name, 'register1')
   t.equal(root.children[1].name, 'sibling')
-  t.equal(root.routes.length, 8)
+  t.equal(root.routes.length, 9)
   t.same(root.routes, require('./fixture/routes.00.json'))
 
   const reg1 = root.children[0]

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd'
 
-import fastify from 'fastify'
+import fastify, { HTTPMethods } from 'fastify'
 import fastifyOverview, { OverviewStructure } from '../../index'
 
 const app = fastify()
@@ -16,5 +16,6 @@ app
   .after((_) => {
     const data = app.overview()
     expectType<OverviewStructure>(data)
+    expectType<HTTPMethods | HTTPMethods[]>(data.routes![0].method)
   })
   .ready()


### PR DESCRIPTION
Currently the method property in `RouteItem` is typed as `HTTPMethods` but with `fastify.route` you can also add an array of routes. I updated the types accordingly and added test cases