### PR TITLE
`transformRouteOptions` plugin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,13 @@ app.register(require('fastify-overview'), {
   exposeRouteOptions: {
     method: 'POST', // default: 'GET'
     url: '/customUrl', // default: '/json-overview'
+  }, 
+  transformRouteOptions: (opts) => {
+    return {
+      method: opts.method,
+      url: opts.url,
+      schema: opts.schema
+    }
   }
 })
 
@@ -293,6 +300,23 @@ By default the route is exposed at `GET /json-overview`.
 
 You can customize the route's options when `exposeRoute` is set to `true`.
 You can provide all the [fastify route's options](https://www.fastify.io/docs/latest/Reference/Routes/#routes-options) except the `handler`.
+
+### transformRouteOptions
+
+This option can be used to determine which properties of the route options are included in the overview. 
+The function receives the [RouteOption](https://github.com/fastify/fastify/blob/62f564d965949bc123184a27a610f214f23e9a49/types/hooks.d.ts#L695) 
+object as the only parameter and must return an object with the desired properties. 
+The hooks and, depending on the [configuration](#addsource), the source are then also appended to the final object.
+The default value if no function is given is:
+```js
+ transformRouteOptions: (routeOptions) => {
+   return {
+     method: routeOptions.method,
+     url: routeOptions.url,
+     prefix: routeOptions.prefix
+   }
+ }
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ You can provide all the [fastify route's options](https://www.fastify.io/docs/la
 ### transformRouteOptions
 
 This option can be used to determine which properties of the route options are included in the overview. 
-The function receives the [RouteOption](https://github.com/fastify/fastify/blob/62f564d965949bc123184a27a610f214f23e9a49/types/hooks.d.ts#L695) 
+The function receives the [RouteOptions](https://github.com/fastify/fastify/blob/62f564d965949bc123184a27a610f214f23e9a49/types/hooks.d.ts#L695) 
 object as the only parameter and must return an object with the desired properties. 
 The hooks and, depending on the [configuration](#addsource), the source are then also appended to the final object.
 The default value if no function is given is:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Doing so you will get a complete overview of your application and you can:
 
 - optimize your code
 - optimize your application structure
-- find out the application structure (expecially if you have joined a new team)
+- find out the application structure (especially if you have joined a new team)
 - automate some documentation tasks
 
 This plugin is intended to be run only for _development_ purposes.
@@ -176,11 +176,9 @@ app.register(require('fastify-overview'), {
   exposeRouteOptions: {
     method: 'POST', // default: 'GET'
     url: '/customUrl', // default: '/json-overview'
-  }, 
-  transformRouteOptions: (opts) => {
+  },
+   onRouteDefinition: (opts) => {
     return {
-      method: opts.method,
-      url: opts.url,
       schema: opts.schema
     }
   }
@@ -301,22 +299,24 @@ By default the route is exposed at `GET /json-overview`.
 You can customize the route's options when `exposeRoute` is set to `true`.
 You can provide all the [fastify route's options](https://www.fastify.io/docs/latest/Reference/Routes/#routes-options) except the `handler`.
 
-### transformRouteOptions
+### onRouteDefinition
 
-This option can be used to determine which properties of the route options are included in the overview. 
+This option can be used to determine which properties of the route options are additional included in the overview. 
 The function receives the [RouteOptions](https://github.com/fastify/fastify/blob/62f564d965949bc123184a27a610f214f23e9a49/types/hooks.d.ts#L695) 
-object as the only parameter and must return an object with the desired properties. 
-The hooks and, depending on the [configuration](#addsource), the source are then also appended to the final object.
-The default value if no function is given is:
+object as the only parameter and must return an object with the desired properties. You can also overwrite the properties 
+that are included in the route overview by default (namely `url`, `method`, `prefix` and `hooks`). You cannot
+override the `source` property.
 ```js
- transformRouteOptions: (routeOptions) => {
+ onRouteDefinition: (routeOptions) => {
    return {
      method: routeOptions.method,
-     url: routeOptions.url,
-     prefix: routeOptions.prefix
+     url: routeOptions.url.length,
+     prefix: routeOptions.prefix,
+     schema: routeOptions.schema
    }
  }
 ```
+In this example, the `url` property is overridden and the `url` length is returned instead of the `url`.
 
 ## License
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,18 +50,18 @@ interface RouteItem {
   source?: OverviewStructureSource,
 }
 
-export interface OverviewStructure {
+export interface OverviewStructure<T = RouteItem> {
   id: Number,
   name: string,
   source?: OverviewStructureSource,
-  children?: OverviewStructure[],
+  children?: OverviewStructure<T>[],
   decorators?: {
     decorate: OverviewStructureDecorator[],
     decorateRequest: OverviewStructureDecorator[],
     decorateReply: OverviewStructureDecorator[]
   },
   hooks?: OverviewStructureHooks,
-  routes?: RouteItem[]
+  routes?: (T & { hooks: OverviewStructureHooks, source?: OverviewStructureSource }) []
 }
 
 export interface FastifyOverviewOptions {
@@ -82,6 +82,11 @@ export interface FastifyOverviewOptions {
    * Customize the route's options when `exposeRoute` is set to `true`
    */
    exposeRouteOptions?: Partial<RouteOptions>,
+
+  /**
+   * Customise which properties of the route options will be included in the overview
+   */
+   transformRouteOptions?: (routeOptions: RouteOptions & { routePath: string; path: string; prefix: string }) => Record<string, unknown>
 }
 
 export interface FastifyOverviewDecoratorOptions {
@@ -98,7 +103,7 @@ export interface FastifyOverviewDecoratorOptions {
 
 declare module 'fastify' {
   export interface FastifyInstance {
-    overview: (opts?: FastifyOverviewDecoratorOptions) => OverviewStructure;
+    overview: <T = RouteItem>(opts?: FastifyOverviewDecoratorOptions) => OverviewStructure<T>;
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,7 +50,7 @@ interface RouteItem {
   source?: OverviewStructureSource,
 }
 
-export interface OverviewStructure<T = RouteItem> {
+export interface OverviewStructure<T = {}> {
   id: Number,
   name: string,
   source?: OverviewStructureSource,
@@ -61,7 +61,7 @@ export interface OverviewStructure<T = RouteItem> {
     decorateReply: OverviewStructureDecorator[]
   },
   hooks?: OverviewStructureHooks,
-  routes?: (T & { hooks: OverviewStructureHooks, source?: OverviewStructureSource }) []
+  routes?: (Omit<RouteItem, keyof T> & T)[]
 }
 
 export interface FastifyOverviewOptions {
@@ -86,7 +86,7 @@ export interface FastifyOverviewOptions {
   /**
    * Customise which properties of the route options will be included in the overview
    */
-   transformRouteOptions?: (routeOptions: RouteOptions & { routePath: string; path: string; prefix: string }) => Record<string, unknown>
+  onRouteDefinition?: (routeOptions: RouteOptions & { routePath: string; path: string; prefix: string }) => Record<string, unknown>
 }
 
 export interface FastifyOverviewDecoratorOptions {
@@ -103,7 +103,7 @@ export interface FastifyOverviewDecoratorOptions {
 
 declare module 'fastify' {
   export interface FastifyInstance {
-    overview: <T = RouteItem>(opts?: FastifyOverviewDecoratorOptions) => OverviewStructure<T>;
+    overview: <T = {}>(opts?: FastifyOverviewDecoratorOptions) => OverviewStructure<T>;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -18,14 +18,7 @@ const {
 
 function fastifyOverview (fastify, options, next) {
   const opts = Object.assign({
-    addSource: false,
-    transformRouteOptions: (routeOptions) => {
-      return {
-        method: routeOptions.method,
-        url: routeOptions.url,
-        prefix: routeOptions.prefix
-      }
-    }
+    addSource: false
   }, options)
 
   const contextMap = new Map()
@@ -38,7 +31,7 @@ function fastifyOverview (fastify, options, next) {
   })
 
   fastify.addHook('onRoute', function markRoute (routeOpts) {
-    const routeNode = transformRoute(routeOpts, opts.transformRouteOptions)
+    const routeNode = Object.assign(transformRoute(routeOpts), opts.onRouteDefinition?.(routeOpts))
     if (opts.addSource) {
       routeNode.source = routeOpts.handler[kSourceRoute]
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,14 @@ const {
 
 function fastifyOverview (fastify, options, next) {
   const opts = Object.assign({
-    addSource: false
+    addSource: false,
+    transformRouteOptions: (routeOptions) => {
+      return {
+        method: routeOptions.method,
+        url: routeOptions.url,
+        prefix: routeOptions.prefix
+      }
+    }
   }, options)
 
   const contextMap = new Map()
@@ -31,7 +38,7 @@ function fastifyOverview (fastify, options, next) {
   })
 
   fastify.addHook('onRoute', function markRoute (routeOpts) {
-    const routeNode = transformRoute(routeOpts)
+    const routeNode = transformRoute(routeOpts, opts.transformRouteOptions)
     if (opts.addSource) {
       routeNode.source = routeOpts.handler[kSourceRoute]
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,9 +21,8 @@ function getFunctionName (func) {
   }
 }
 
-function transformRoute (routeOpts) {
+function transformRoute (routeOpts, transformRouteOptions) {
   const hooks = getEmptyHookRoute()
-
   for (const hook of Object.keys(hooks)) {
     if (routeOpts[hook]) {
       if (Array.isArray(routeOpts[hook])) {
@@ -35,9 +34,7 @@ function transformRoute (routeOpts) {
   }
 
   return {
-    method: routeOpts.method,
-    url: routeOpts.url,
-    prefix: routeOpts.prefix,
+    ...transformRouteOptions(routeOpts),
     hooks
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,7 +21,7 @@ function getFunctionName (func) {
   }
 }
 
-function transformRoute (routeOpts, transformRouteOptions) {
+function transformRoute (routeOpts) {
   const hooks = getEmptyHookRoute()
   for (const hook of Object.keys(hooks)) {
     if (routeOpts[hook]) {
@@ -34,7 +34,9 @@ function transformRoute (routeOpts, transformRouteOptions) {
   }
 
   return {
-    ...transformRouteOptions(routeOpts),
+    method: routeOpts.method,
+    url: routeOpts.url,
+    prefix: routeOpts.prefix,
     hooks
   }
 }

--- a/test/fixture/routes.04.json
+++ b/test/fixture/routes.04.json
@@ -1,0 +1,42 @@
+[
+  {
+    "method": "GET",
+    "url":"/get",
+    "prefix":"",
+    "bodySchema": null,
+    "hooks":{
+      "onRequest":[ ],
+      "preParsing":[ ],
+      "preValidation":[ ],
+      "preHandler":[ ],
+      "preSerialization":[ ],
+      "onError":[ ],
+      "onSend":[ ],
+      "onResponse":[ ],
+      "onTimeout":[ ],
+      "onRequestAbort":[ ]
+    }
+  },
+  {
+    "method": "POST",
+    "url":"/post",
+    "prefix":"",
+    "bodySchema": {
+        "test": {
+          "type": "string"
+        }
+    },
+    "hooks":{
+      "onRequest":[ ],
+      "preParsing":[ ],
+      "preValidation":[ ],
+      "preHandler":[ ],
+      "preSerialization":[ ],
+      "onError":[ ],
+      "onSend":[ ],
+      "onResponse":[ ],
+      "onTimeout":[ ],
+      "onRequestAbort":[ ]
+    }
+  }
+]

--- a/test/fixture/routes.05.json
+++ b/test/fixture/routes.05.json
@@ -1,0 +1,20 @@
+[
+  {
+    "method": "PUT",
+    "url":"/api/plugin",
+    "prefix":"/api",
+    "bodySchema": null,
+    "hooks":{
+      "onRequest":[ ],
+      "preParsing":[ ],
+      "preValidation":[ ],
+      "preHandler":[ ],
+      "preSerialization":[ ],
+      "onError":[ ],
+      "onSend":[ ],
+      "onResponse":[ ],
+      "onTimeout":[ ],
+      "onRequestAbort":[ ]
+    }
+  }
+]

--- a/test/fixture/routes.06.json
+++ b/test/fixture/routes.06.json
@@ -1,0 +1,24 @@
+[
+  {
+    "method": "PATCH",
+    "url":"/api/patch/:param",
+    "prefix":"/api",
+    "bodySchema": {
+      "text": {
+        "type": "boolean"
+      }
+    },
+    "hooks":{
+      "onRequest":[ ],
+      "preParsing":[ ],
+      "preValidation":[ ],
+      "preHandler":[ ],
+      "preSerialization":[ ],
+      "onError":[ ],
+      "onSend":[ ],
+      "onResponse":[ ],
+      "onTimeout":[ ],
+      "onRequestAbort":[ ]
+    }
+  }
+]

--- a/test/fixture/routes.07.json
+++ b/test/fixture/routes.07.json
@@ -1,0 +1,36 @@
+[
+  {
+    "method": "GETGET",
+    "url":"static url",
+    "prefix":"",
+    "hooks":{
+      "onRequest":[ ],
+      "preParsing":[ ],
+      "preValidation":[ ],
+      "preHandler":[ ],
+      "preSerialization":[ ],
+      "onError":[ ],
+      "onSend":[ ],
+      "onResponse":[ ],
+      "onTimeout":[ ],
+      "onRequestAbort":[ ]
+    }
+  },
+  {
+    "method": "POSTPOST",
+    "url":"static url",
+    "prefix":"",
+    "hooks":{
+      "onRequest":[ ],
+      "preParsing":[ ],
+      "preValidation":[ ],
+      "preHandler":[ ],
+      "preSerialization":[ ],
+      "onError":[ ],
+      "onSend":[ ],
+      "onResponse":[ ],
+      "onTimeout":[ ],
+      "onRequestAbort":[ ]
+    }
+  }
+]

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -93,3 +93,58 @@ test('routes', async t => {
   t.same(reg3.routes.length, 9)
   t.same(reg3.routes, require('./fixture/routes.03.json'))
 })
+
+test('custom transformRouteOptions', async t => {
+  const app = fastify({ exposeHeadRoutes: false })
+
+  await app.register(plugin, {
+    transformRouteOptions: (opts) => {
+      return {
+        url: opts.url,
+        prefix: opts.prefix,
+        method: opts.method,
+        bodySchema: opts.schema ? opts.schema.body : undefined
+      }
+    }
+  })
+
+  app.get('/get', noop)
+  app.post('/post', { schema: { body: { test: { type: 'string' } } } }, noop)
+
+  app.register(async (instance) => {
+    instance.put('/plugin', { schema: { querystring: { size: { type: 'integer' } } } }, noop)
+
+    instance.register(async function (instance2) {
+      instance2.patch('/patch/:param', {
+        schema: {
+          params: {
+            param: {
+              type: 'string'
+            }
+          },
+          body: {
+            text: {
+              type: 'boolean'
+            }
+          }
+        }
+      }, noop)
+    })
+  }, { prefix: 'api' })
+
+  await app.ready()
+
+  const root = app.overview()
+
+  t.equal(root.children.length, 1)
+  t.equal(root.routes.length, 2)
+  t.same(root.routes, require('./fixture/routes.04.json'))
+
+  t.equal(root.children[0].routes.length, 1)
+  t.equal(root.children[0].children.length, 1)
+  t.same(root.children[0].routes, require('./fixture/routes.05.json'))
+
+  t.equal(root.children[0].children[0].routes.length, 1)
+  t.equal(root.children[0].children[0].children.length, 0)
+  t.same(root.children[0].children[0].routes, require('./fixture/routes.06.json'))
+})

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -21,7 +21,7 @@ app
 
 app
   .register(fastifyOverview, {
-    transformRouteOptions: (routeOptions) => {
+    onRouteDefinition: (routeOptions) => {
       return {
         bodySchema: routeOptions.schema?.body,
         headerNames: Object.keys(routeOptions.schema?.headers ?? {})
@@ -31,6 +31,20 @@ app
   .after((_) => {
     const data = app.overview<{ bodySchema: {}, headerNames: string[] }>()
     expectType<OverviewStructure<{ bodySchema: {}, headerNames: string[] }>>(data)
-    expectError<OverviewStructure>(data)
+  })
+  .ready()
+
+app
+  .register(fastifyOverview, {
+    onRouteDefinition: (routeOptions) => {
+      return {
+        url: routeOptions.url.length
+      }
+    }
+  })
+  .after((_) => {
+    const data = app.overview<{ url: number }>()
+    expectType<OverviewStructure<{ url: number }>>(data)
+    expectType<number>(data.routes![0].url)
   })
   .ready()

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,4 +1,4 @@
-import { expectType } from 'tsd'
+import { expectError, expectType } from 'tsd'
 
 import fastify from 'fastify'
 import fastifyOverview, { OverviewStructure } from '../../index'
@@ -16,5 +16,21 @@ app
   .after((_) => {
     const data = app.overview()
     expectType<OverviewStructure>(data)
+  })
+  .ready()
+
+app
+  .register(fastifyOverview, {
+    transformRouteOptions: (routeOptions) => {
+      return {
+        bodySchema: routeOptions.schema?.body,
+        headerNames: Object.keys(routeOptions.schema?.headers ?? {})
+      }
+    }
+  })
+  .after((_) => {
+    const data = app.overview<{ bodySchema: {}, headerNames: string[] }>()
+    expectType<OverviewStructure<{ bodySchema: {}, headerNames: string[] }>>(data)
+    expectError<OverviewStructure>(data)
   })
   .ready()

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,4 +1,4 @@
-import { expectError, expectType } from 'tsd'
+import { expectType } from 'tsd'
 
 import fastify from 'fastify'
 import fastifyOverview, { OverviewStructure } from '../../index'


### PR DESCRIPTION
As discussed in #93, this PR adds the `transformRouteOptions` plugin option. With this option, you can now fully customize which properties the routes overview object will contain.